### PR TITLE
Ability to run smart-log in silent mode

### DIFF
--- a/bin/git-smart-log
+++ b/bin/git-smart-log
@@ -4,4 +4,5 @@ $:.unshift(File.join(File.expand_path(File.dirname(__FILE__)), '..', 'lib'))
 
 require 'git-smart'
 
+$stdout = STDERR
 GitSmart.run('smart-log', ARGV)


### PR DESCRIPTION
I run gl pretty often and I set LESS to clear terminal after quitting, so I see a lot of:

```
$ gl
Executing: git log --pretty=format:%C(yellow)%h%Cblue%d%Creset %s %C(white) %an, %ar%Creset --graph
$ gl 
Executing: git log --pretty=format:%C(yellow)%h%Cblue%d%Creset %s %C(white) %an, %ar%Creset --graph
$ gl
Executing: git log --pretty=format:%C(yellow)%h%Cblue%d%Creset %s %C(white) %an, %ar%Creset --graph
```

Therefore I would like ability to prevent output of obvious `Executing: ...` line, I did it in this pull-request by redirecting it to STDERR, so I can silence it with `alias gl='git smart-log 2>/dev/null` without affecting functionality of this command.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/geelen/git-smart/15)

<!-- Reviewable:end -->
