### PR TITLE
Support for subdirectories

### DIFF
--- a/lib/git-smart/git_repo.rb
+++ b/lib/git-smart/git_repo.rb
@@ -2,7 +2,10 @@ class GitRepo
   def initialize(dir)
     @dir = dir
     if !File.exists? File.join(@dir, ".git")
-      raise GitSmart::RunFailed.new("You need to run this from within a git directory")
+      @dir = git('rev-parse', '--show-toplevel').chomp
+      if !File.exists? File.join(@dir, ".git")
+        raise GitSmart::RunFailed.new("You need to run this from within a git directory")
+      end
     end
   end
 


### PR DESCRIPTION
I run git from repository subdirectories all the time so I spent some time figuring out why smart-pull wasn't working. Makes the smart-pull interface more compatible with vanilla git.
