### PR TITLE
Prevent a "stash pop" if "stash" reports "No local changes to save"

### DIFF
--- a/lib/commands/smart-merge.rb
+++ b/lib/commands/smart-merge.rb
@@ -42,17 +42,17 @@ GitSmart.register 'smart-merge' do |repo, args|
     end
 
     #Before we merge, detect if there are local changes and stash them.
-    stash_required = repo.dirty?
-    if stash_required
+    pop_required = false
+    if repo.dirty?
       note "Working directory dirty. Stashing..."
-      repo.stash!
+      pop_required = repo.stash!
     end
 
     #Perform the merge, using --no-ff.
     repo.merge_no_ff!(merge_target)
 
-    #If we stashed before, pop now.
-    if stash_required
+    #If we successfully stashed before, pop now.
+    if pop_required
       note "Reapplying local changes..."
       repo.stash_pop!
     end

--- a/lib/commands/smart-pull.rb
+++ b/lib/commands/smart-pull.rb
@@ -70,10 +70,10 @@ GitSmart.register 'smart-pull' do |repo, args|
       note "There #{is_are} #{new_commits_on_remote.length} new commit#{s_or_not} on '#{upstream_branch}'."
 
       #Next, detect if there are local changes and stash them.
-      stash_required = repo.dirty?
-      if stash_required
+      pop_required = false
+      if repo.dirty?
         note "Working directory dirty. Stashing..."
-        repo.stash!
+        pop_required = repo.stash!
       end
 
       success_messages = []
@@ -95,8 +95,8 @@ GitSmart.register 'smart-pull' do |repo, args|
         success_messages << "HEAD moved from #{head[0,7]} to #{repo.sha('HEAD')[0,7]}."
       end
 
-      #If we stashed before, pop now.
-      if stash_required
+      #If we successfully stashed before, pop now.
+      if pop_required
         note "Reapplying local changes..."
         repo.stash_pop!
       end

--- a/lib/git-smart/git_repo.rb
+++ b/lib/git-smart/git_repo.rb
@@ -82,7 +82,7 @@ class GitRepo
   end
 
   def stash!
-    git!('stash')
+    !git!('stash').split("\n").include?("No local changes to save")
   end
 
   def stash_pop!


### PR DESCRIPTION
This happens with dirty submodules.  I've tested these changes for about a month now with no problems, albeit only with pull as I don't use smart merge.
