### PR TITLE
Fix smart-pull hanging when remote repository is up to date.

### DIFF
--- a/lib/git-smart/git_repo.rb
+++ b/lib/git-smart/git_repo.rb
@@ -60,7 +60,7 @@ class GitRepo
   end
 
   def fetch!(remote)
-    git!('fetch', remote, '--verbose')
+    git!('fetch', remote)
   end
 
   def merge_base(ref_a, ref_b)

--- a/lib/git-smart/safe_shell.rb
+++ b/lib/git-smart/safe_shell.rb
@@ -7,11 +7,8 @@ module SafeShell
     exit_status = nil
 
     Open3.popen2e (cmd) do |stdin, out, wait_thr|
-      while line = out.gets
-        result += line
-      end
-
       exit_status = wait_thr.value
+      result = out.read
     end
 
     return result, exit_status


### PR DESCRIPTION
Running `git fetch <remote>` in git 1.8+ outputs nothing to STDOUT or STDERR if the remote is up-to-date. By changing the fetch command to use --verbose, we ensure something is always output when git fetch runs, even if the remote is up-to-date. This will prevent the IO.pipe from hanging when executing the git fetch command.

For bonus points, I switched to using Open3#popen2e instead of using Kernel#exec. Now the handling of sub-processes is abstracted away, and we can wait for, read and handle the exit status of the process more deterministically.
