### PR TITLE
Handle local renamed but uncommitted files (git mv).

### DIFF
--- a/lib/git-smart/git_repo.rb
+++ b/lib/git-smart/git_repo.rb
@@ -90,10 +90,11 @@ class GitRepo
         case status
           when /^[^ ]*M/; :modified
           when /^[^ ]*A/; :added
+          when /^[^ ]*R/; :renamed
           when /^[^ ]*D/; :deleted
           when /^[^ ]*\?\?/; :untracked
           when /^[^ ]*UU/; :conflicted
-          else raise GitSmart::UnexpectedOutput.new("Expected the output of git status to only have lines starting with A, M, D, UU, or ??. Got: \n#{raw_status}")
+          else raise GitSmart::UnexpectedOutput.new("Expected the output of git status to only have lines starting with A, M, R, D, UU, or ??. Got: \n#{raw_status}")
         end
       }
   end


### PR DESCRIPTION
Accept `git status` output lines beginning with R in addition to the already accepted prefixes (A, M, D, UU, or ??).

I'm not convinced that the git status after popping is correct. The status is:
`local_dir.should have_git_status({:deleted=>["lib/codes.rb"], :added=>["lib/codes2.rb"]})`
I would expect:
`local_dir.should have_git_status({:renamed=>["lib/codes2.rb"]})`