### PR TITLE
Add support for a pre-smart-pull hook

### DIFF
--- a/lib/commands/smart-pull.rb
+++ b/lib/commands/smart-pull.rb
@@ -21,6 +21,9 @@ GitSmart.register 'smart-pull' do |repo, args|
     note("No tracking remote configured, assuming 'origin'") ||
     'origin'
 
+  # Run smart-pull-pre-fetch hook
+  repo.run_hook('smart-pull-pre-fetch')
+
   # Fetch the remote. This pulls down all new commits from the server, not just our branch,
   # but generally that's a good thing. This is the only communication we need to do with the server.
   repo.fetch!(tracking_remote)

--- a/lib/git-smart/git_repo.rb
+++ b/lib/git-smart/git_repo.rb
@@ -59,6 +59,14 @@ class GitRepo
     end
   end
 
+  def run_hook(hook_file)
+    full_path = File.join(git_dir, 'hooks', hook_file)
+    if File.exists?(full_path)
+      output = SafeShell.execute(full_path)
+      $?.success? ? puts(output) : raise(GitSmart::UnexpectedOutput.new(output))
+    end
+  end
+
   def fetch!(remote)
     git!('fetch', remote)
   end

--- a/spec/smart-pull_spec.rb
+++ b/spec/smart-pull_spec.rb
@@ -36,6 +36,21 @@ describe 'smart-pull' do
     out.should report("Already up-to-date")
   end
 
+  context "with a smart-pull-pre-fetch hook" do
+    before :each do
+      %x[
+        cd #{local_dir}
+          printf '#!/bin/bash\n\necho running hook...done\n' > .git/hooks/smart-pull-pre-fetch
+          chmod 755 .git/hooks/smart-pull-pre-fetch
+      ]
+    end
+
+    it "should run the hook" do
+      out = run_command(local_dir, 'smart-pull')
+      out.should report("running hook...done")
+    end
+  end
+
   context "with only local changes" do
     before :each do
       %x[


### PR DESCRIPTION
User can create and executable script in
.git/hooks/smart-pull-pre-fetch that will
be executed just before a fetch.

Example: There are tags in remote that need to be
cleaned out. One team member cleans them out but
then they come back the next time someone else
pushes a local tag before syncing local tags to
remote. A solution to this problem is to create
a smart-pull-pre-fetch hook that syncs local
tags to remote tags, so that old tags previously
deleted on remote don't come back.