### PR TITLE
replace --preserve-merges with --rebase-merges

### DIFF
--- a/lib/git-smart/git_repo.rb
+++ b/lib/git-smart/git_repo.rb
@@ -115,7 +115,7 @@ class GitRepo
   end
 
   def rebase_preserving_merges!(upstream)
-    git!('rebase', '-p', upstream)
+    git!('rebase', '--rebase-merges', upstream)
   end
 
   def read_log(nr)


### PR DESCRIPTION
git 2.34 removed --preserved-merges, replacing with suggested command