### PR TITLE
Ruby 322 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,34 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    colorize (0.5.8)
-    diff-lcs (1.1.3)
-    docile (1.1.1)
-    multi_json (1.8.2)
-    mustache (0.99.4)
-    rake (10.0.3)
-    redcarpet (1.17.2)
+    colorize (1.1.0)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    mustache (1.1.1)
+    rake (13.0.6)
+    redcarpet (3.6.0)
     rocco (0.8.2)
       mustache
       redcarpet
-    rspec (2.7.0)
-      rspec-core (~> 2.7.0)
-      rspec-expectations (~> 2.7.0)
-      rspec-mocks (~> 2.7.0)
-    rspec-core (2.7.1)
-    rspec-expectations (2.7.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.7.0)
-    simplecov (0.8.2)
-      docile (~> 1.1.0)
-      multi_json
-      simplecov-html (~> 0.8.0)
-    simplecov-html (0.8.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
 
 PLATFORMS
   ruby
@@ -34,3 +39,6 @@ DEPENDENCIES
   rocco
   rspec
   simplecov
+
+BUNDLED WITH
+   2.4.13

--- a/lib/git-smart/git_repo.rb
+++ b/lib/git-smart/git_repo.rb
@@ -20,7 +20,7 @@ class GitRepo
   def git_dir
     gitdir = Pathname.new(@dir).join('.git')
 
-    unless File.exists?(gitdir)
+    unless File.exist?(gitdir)
       @dir = git('rev-parse', '--show-toplevel').chomp
       gitdir = Pathname.new(@dir).join('.git') unless @dir.empty?
     end

--- a/spec/smart-pull_spec.rb
+++ b/spec/smart-pull_spec.rb
@@ -130,7 +130,7 @@ describe 'smart-pull' do
       out.should report("There is 1 new commit on 'origin/master'.")
       out.should report("You have 1 new commit on 'master'.")
       out.should report("Both local and remote branches have moved on. Branch 'master' needs to be rebased onto 'origin/master'")
-      out.should report("Executing: git rebase -p origin/master")
+      out.should report("Executing: git rebase --rebase-merges origin/master")
       out.should report("Successfully rebased and updated refs/heads/master.")
       local_dir.should have_last_few_commits(['local changes', 'upstream changes', 'first'])
     end
@@ -142,7 +142,7 @@ describe 'smart-pull' do
       ]
       local_dir.should have_git_status({:untracked => ['noob']})
       out = run_command(local_dir, 'smart-pull')
-      out.should report("Executing: git rebase -p origin/master")
+      out.should report("Executing: git rebase --rebase-merges origin/master")
       out.should report("Successfully rebased and updated refs/heads/master.")
       local_dir.should have_git_status({:untracked => ['noob']})
       local_dir.should have_last_few_commits(['local changes', 'upstream changes', 'first'])
@@ -159,7 +159,7 @@ describe 'smart-pull' do
       out = run_command(local_dir, 'smart-pull')
       out.should report("Working directory dirty. Stashing...")
       out.should report("Executing: git stash")
-      out.should report("Executing: git rebase -p origin/master")
+      out.should report("Executing: git rebase --rebase-merges origin/master")
       out.should report("Successfully rebased and updated refs/heads/master.")
       local_dir.should have_git_status({:added => ['noob'], :modified => ['lib/codes.rb']})
       local_dir.should have_last_few_commits(['local changes', 'upstream changes', 'first'])
@@ -181,7 +181,7 @@ describe 'smart-pull' do
           git commit -m 'first'
         cd ..
         cd local
-          git submodule add "${PWD}/../submodule/.git" submodule
+          git -c protocol.file.allow=always submodule add "${PWD}/../submodule/.git" submodule
           git commit -am 'Add submodule'
       ]
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ RSpec.configure do |config|
     FileUtils.rm_rf WORKING_DIR
     FileUtils.mkdir_p WORKING_DIR
   end
+  
+  config.expect_with(:rspec) { |c| c.syntax = :should }
 
   config.after :each do
     FileUtils.rm_rf WORKING_DIR
@@ -27,10 +29,10 @@ def run_command(dir, command, *args)
 end
 
 RSpec::Matchers.define :report do |expected|
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     "expected to see #{expected.inspect}, got \n\n#{actual.map { |line| "  #{line}" }.join("\n")}"
   end
-  failure_message_for_should_not do |actual|
+  failure_message_when_negated do |actual|
     "expected not to see #{expected.inspect} in \n\n#{actual.map { |line| "  #{line}" }.join("\n")}"
   end
   match do |actual|
@@ -40,10 +42,10 @@ end
 
 
 RSpec::Matchers.define :have_git_status do |expected|
-  failure_message_for_should do |dir|
+  failure_message do |dir|
     "expected '#{dir}' to have git status of #{expected.inspect}, got #{GitRepo.new(dir).status.inspect}"
   end
-  failure_message_for_should_not do |actual|
+  failure_message_when_negated do |actual|
     "expected '#{dir}' to not have git status of #{expected.inspect}, got #{GitRepo.new(dir).status.inspect}"
   end
   match do |dir|
@@ -53,10 +55,10 @@ end
 
 
 RSpec::Matchers.define :have_last_few_commits do |expected|
-  failure_message_for_should do |dir|
+  failure_message do |dir|
     "expected '#{dir}' to have last few commits of #{expected.inspect}, got #{GitRepo.new(dir).last_commit_messages(expected.length).inspect}"
   end
-  failure_message_for_should_not do |actual|
+  failure_message_when_negated do |actual|
     "expected '#{dir}' to not have git status of #{expected.inspect}, got #{GitRepo.new(dir).last_commit_messages(expected.length).inspect}"
   end
   match do |dir|


### PR DESCRIPTION
Ruby 3.2 deprecated support for `File.exists?`

This PR duplicates the work done in https://github.com/geelen/git-smart/pull/35 to support Ruby 3.2.x and also updates the bundle and test suite for a green build.